### PR TITLE
Change the future.delay to Timer implementation, and make the ToastFu…

### DIFF
--- a/lib/src/core/toast.dart
+++ b/lib/src/core/toast.dart
@@ -147,7 +147,7 @@ ToastFuture showToastWidget(
 
   future = ToastFuture._(entry, onDismiss, key, animationDuration);
 
-  Future.delayed(duration, () {
+  future.timer = Timer(duration, (){
     future.dismiss();
   });
 

--- a/lib/src/core/toast_future.dart
+++ b/lib/src/core/toast_future.dart
@@ -5,6 +5,7 @@ class ToastFuture {
   final OverlayEntry _entry;
   final VoidCallback _onDismiss;
   bool _isShow = true;
+  Timer timer;
   final GlobalKey<__ToastContainerState> _containerKey;
   final Duration animationDuration;
 
@@ -31,5 +32,8 @@ class ToastFuture {
     } else {
       _entry.remove();
     }
+
+    timer?.cancel();
+    timer = null;
   }
 }


### PR DESCRIPTION
Change the future.delay to Timer implementation, and make the ToastFuture.dismiss method eliminate the memory leak caused by future.delay not being executed.

把Future.delay改成Timer实现，使ToastFuture.dismiss方法可以消除Future.delay未被执行造成的内存泄漏。