### PR TITLE
Replace debugDoingBuild flag with SchedulerPhase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.3.1
+
+- Replace `context.debugDoingBuild` flag with `SchedulerBinding.instance.schedulerPhase`. (#97)
+
 ## 3.3.0
 
 - Abstract `BuildContextPredicate`. (#95)

--- a/lib/src/core/toast.dart
+++ b/lib/src/core/toast.dart
@@ -5,6 +5,7 @@ import 'dart:collection';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart' hide Overlay, OverlayEntry, OverlayState;
+import 'package:flutter/scheduler.dart';
 
 import '../widget/animation/animation_builder.dart';
 import '../widget/overlay.dart';
@@ -189,7 +190,7 @@ ToastFuture showToastWidget(
     }
   }
 
-  if (!context.debugDoingBuild && context.owner?.debugBuilding != true) {
+  if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
     insertOverlayEntry();
   } else {
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: oktoast
 description: A pure flutter toast library, support custom style/widget, easy achieve the same effect with native toasts.
 email: cjl_spy@163.com
 homepage: https://github.com/OpenFlutter/flutter_oktoast
-version: 3.3.0
+version: 3.3.1
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
Replace context.debugDoingBuild flag with SchedulerBinding.instance.schedulerPhase. 'debugDoingBuild' is only valid in debug mode and it should not be used in release mode, 'SchedulerBinding.instance.schedulerPhase' can be used instead.