### PR TITLE
Feat--wrapper-material

### DIFF
--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         version: [
-          '', # Stable
-          '3.0.0' # Minimum
+          '3.16.0', # Stable
+          '3.7.0' # Minimum
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: [ macos-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'

--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze on ${{ matrix.os }}
+    name: Analyze on ${{ matrix.os }} with flutter ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Feat:
 
 - Wrapper a `Material` widget when the `OKToast` widget is not wrapped with `Material`.
+- The min support of flutter SDK version to 3.7.0.
 
 ## 3.3.2+1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 3.4.0
+
+Feat:
+
+- Wrapper a `Material` widget when the `OKToast` widget is not wrapped with `Material`.
+
 ## 3.3.2+1
 
 - Fix `Theatre` constructor and get rid of `View` for compatibilities. (#103)

--- a/lib/src/widget/oktoast.dart
+++ b/lib/src/widget/oktoast.dart
@@ -89,7 +89,7 @@ class _OKToastState extends State<OKToast> {
       ],
     );
 
-    final Widget w = Directionality(
+    Widget w = Directionality(
       textDirection: widget.textDirection,
       child: overlay,
     );
@@ -101,6 +101,15 @@ class _OKToastState extends State<OKToast> {
 
     final OKToastAnimationBuilder animationBuilder =
         widget.animationBuilder ?? _defaultBuildAnimation;
+
+    final haveMaterialParent = Material.maybeOf(context) != null;
+
+    if (!haveMaterialParent) {
+      w = Material(
+        color: Colors.transparent,
+        child: w,
+      );
+    }
 
     return ToastTheme(
       backgroundColor: widget.backgroundColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: oktoast
 description: A pure flutter toast library, support custom style/widget, easy achieve the same effect with native toasts.
 repository: https://github.com/OpenFlutter/flutter_oktoast
-version: 3.3.2+1
+version: 3.4.0
 
 environment:
   sdk: '>=2.17.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 3.4.0
 
 environment:
   sdk: '>=2.17.0 <4.0.0'
-  flutter: '>=3.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
If user use the builder method, there will be no Material component package by default, causing the pop-up toast to contain double yellow underlines. Although users can wrap it themselves, one will be added by default now.